### PR TITLE
feat: Add robust CLI and main script execution tests

### DIFF
--- a/py-load-pmda/tests/test_main.py
+++ b/py-load-pmda/tests/test_main.py
@@ -1,0 +1,54 @@
+import subprocess
+import sys
+
+import pytest
+
+
+def test_main_script_execution():
+    """
+    Tests that the cli.py script can be executed directly.
+    We pass '--help' to ensure it runs and exits cleanly without
+    performing any real operations.
+    """
+    # Get the path to the current python executable
+    python_executable = sys.executable
+    # Get the path to the cli.py script
+    cli_path = "src/py_load_pmda/cli.py"
+
+    # Execute the script as a subprocess
+    result = subprocess.run(
+        [python_executable, cli_path, "--help"],
+        capture_output=True,
+        text=True,
+        check=False,  # Don't raise exception on non-zero exit
+    )
+
+    # Assert that the script ran successfully
+    assert result.returncode == 0
+    # Assert that the help message was printed
+    assert "Usage:" in result.stdout
+    assert "init-db" in result.stdout
+    assert "run" in result.stdout
+    assert "status" in result.stdout
+
+
+def test_main_script_handles_error():
+    """
+    Tests that the cli.py script handles errors gracefully when executed directly.
+    """
+    python_executable = sys.executable
+    cli_path = "src/py_load_pmda/cli.py"
+
+    # Execute the script with an invalid command
+    result = subprocess.run(
+        [python_executable, cli_path, "invalid-command"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    # Assert that the script exited with a non-zero status code
+    assert result.returncode != 0
+    # Assert that an error message was printed
+    assert "Error" in result.stderr
+    assert "No such command 'invalid-command'" in result.stderr


### PR DESCRIPTION
This commit adds several new tests to improve the robustness of the test suite.

- A new test is added to `tests/test_cli.py` to ensure that the CLI handles `BrokenPipeError` gracefully. This simulates scenarios where the output of the CLI is piped to a command that terminates early, such as `head`.

- A new test file, `tests/test_main.py`, is added to test the direct execution of the `cli.py` script. This ensures that the main entry point of the application is working correctly and that it handles errors gracefully when run as a standalone script.