### PR TITLE
fix(ci): Install poetry using pip in GitHub Actions workflow (#68)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,8 @@ jobs:
         cache: 'poetry'
 
     - name: Install Poetry
-      uses: snok/install-poetry@v1
-      with:
-        version: '1.8.2'
+      run: |
+        pip install poetry==1.8.2
 
     - name: Install dependencies
       working-directory: ./py-load-pmda


### PR DESCRIPTION
The previous method using snok/install-poetry@v1 was failing to find the poetry executable. This change replaces the action with a direct pip install command to ensure poetry is installed and available in the PATH.