### PR TITLE
Fix: Use snok/install-poetry action to fix CI build (#70)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-        cache: 'poetry'
 
     - name: Install Poetry
-      run: |
-        pip install poetry==1.8.2
+      uses: snok/install-poetry@v1
+      with:
+        version: 1.8.2
+        virtualenvs-create: true
+        virtualenvs-in-project: true
 
     - name: Install dependencies
       working-directory: ./py-load-pmda


### PR DESCRIPTION
The GitHub Actions workflow was failing because the poetry executable could not be found. This was because the `actions/setup-python` action with the `cache: 'poetry'` option no longer installs poetry.

This commit fixes the issue by using the `snok/install-poetry@v1` action to install poetry in the CI environment. This is the recommended way to install poetry in GitHub Actions.