### PR TITLE
feat: Add multi-OS and multi-python CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,90 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  test-ubuntu:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: latest
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Check if lock file is up to date
+      working-directory: ./py-load-pmda
+      run: poetry check --lock
+
+    - name: Install dependencies
+      working-directory: ./py-load-pmda
+      run: poetry install --no-interaction
+
+    - name: Run tests
+      working-directory: ./py-load-pmda
+      run: poetry run pytest
+
+  test-macos:
+    runs-on: macos-latest
+    needs: test-ubuntu
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: latest
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Check if lock file is up to date
+      working-directory: ./py-load-pmda
+      run: poetry check --lock
+
+    - name: Install dependencies
+      working-directory: ./py-load-pmda
+      run: poetry install --no-interaction
+
+    - name: Run tests
+      working-directory: ./py-load-pmda
+      run: poetry run pytest
+
+  test-windows:
+    runs-on: windows-latest
+    needs: test-macos
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install Poetry
       uses: snok/install-poetry@v1


### PR DESCRIPTION
This commit updates the CI configuration to run tests on multiple operating systems (Ubuntu, macOS, and Windows) and multiple Python versions (3.9, 3.10, 3.11, 3.12).

The OS tests are serialized in the following order: Ubuntu, then macOS, and then Windows.